### PR TITLE
Updated lib/rapidjson submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/zaphoyd/websocketpp.git
 [submodule "lib/rapidjson"]
 	path = lib/rapidjson
-	url = https://github.com/miloyip/rapidjson.git
+	url = https://github.com/Tencent/rapidjson.git
 [submodule "lib/asio"]
 	path = lib/asio
 	url = https://github.com/chriskohlhoff/asio.git


### PR DESCRIPTION
Fixed an unexpected "Bus error: 10" runtime error when calling Document::FindMember method in from_json function at sio_packet.cpp. Fixed replacing the current rapidjson submodule url by the oficial git repo url.